### PR TITLE
Add safety check to utility method

### DIFF
--- a/CyclopsSpeedUpgrades/Utils/CyclopsSpeedModuleUtils.cs
+++ b/CyclopsSpeedUpgrades/Utils/CyclopsSpeedModuleUtils.cs
@@ -13,6 +13,8 @@ namespace CyclopsSpeedUpgrades.Utils
          */
         public static BaseCyclopsSpeedModule GetInstalled(UpgradeConsole upgradeConsole)
         {
+            if(!upgradeConsole) return null;
+            
             var installedSpeedModules =
                 upgradeConsole.modules.equipment.Values
                               .Where(m => m != null && m.item != null)


### PR DESCRIPTION
Created because the seal submarine currently has an incompatibility with this mod, due to not having the upgrade console accessible in the way this mod expects it to be. This one line should fix it, although I also haven't tested this to be sure.